### PR TITLE
Fix: Prevent text from being cut off at the bottom when persisted

### DIFF
--- a/src/components/smoke-genius/SmokeCanvas.tsx
+++ b/src/components/smoke-genius/SmokeCanvas.tsx
@@ -53,7 +53,7 @@ const BASE_SMOKE_LIFESPAN = 300;
 const BOTTOM_SOURCE_X_SPREAD = 12.0;
 
 const TEXT_CANVAS_WIDTH = 2048;
-const TEXT_CANVAS_HEIGHT = 256;
+const TEXT_CANVAS_HEIGHT = 320;
 const TEXT_FONT_SIZE = 110;
 const TEXT_FONT = `bold ${TEXT_FONT_SIZE}px Arial, sans-serif`;
 const TEXT_SAMPLE_DENSITY = 3.0;
@@ -530,7 +530,7 @@ const SmokeCanvas: React.FC<SmokeCanvasProps> = ({
     ctx.fillStyle = '#ffffff';
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
-    ctx.fillText(text, canvas.width / 2, canvas.height / 2);
+    ctx.fillText(text, canvas.width / 2, canvas.height / 2 - TEXT_FONT_SIZE / 4);
 
     const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
     const data = imageData.data;
@@ -554,7 +554,7 @@ const SmokeCanvas: React.FC<SmokeCanvasProps> = ({
         for (let i = 1; i < points.length; i++) {
             if (points[i].y < minY) minY = points[i].y;
         }
-        const desiredMinSceneY = -0.4;
+        const desiredMinSceneY = -0.5;
         if (minY < desiredMinSceneY) {
             const shiftAmount = desiredMinSceneY - minY;
             for (let i = 0; i < points.length; i++) {


### PR DESCRIPTION
The issue was caused by a combination of factors:
1. The 2D canvas used for rendering text points (`TEXT_CANVAS_HEIGHT`) was not tall enough, potentially clipping descenders.
2. The vertical alignment of text on this 2D canvas did not provide sufficient buffer at the bottom.
3. The subsequent vertical adjustment logic (`desiredMinSceneY`) in the 3D scene might have pushed the text further down, exacerbating any initial clipping.

This commit addresses the issue by:
- Increasing `TEXT_CANVAS_HEIGHT` from 256 to 320.
- Adjusting the `fillText` y-coordinate in `generateTextPoints` to `canvas.height / 2 - TEXT_FONT_SIZE / 4`, effectively shifting the text rendering upwards on its 2D canvas.
- Modifying `desiredMinSceneY` from -0.4 to -0.5 in `generateTextPoints` to refine the vertical positioning in the 3D scene, preventing it from being pushed too low.

These changes ensure that the text has adequate space to render fully and is positioned correctly in the simulation.